### PR TITLE
__getattr__ improvements and bugfixes

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -5205,31 +5205,44 @@ class Base(ABC):
     ############################
         
     def __getattr__(self, name):
-        try:
-            super().__getattr__(name)
-        except AttributeError as e:
-            if name == "hist":
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Try .plotFeatureDistribution() instead.") from e
-            elif name == 'describe':
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Try .report() instead.") from e
-            elif name == "columns":
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Try .features.getNames() instead.") from e
-            elif name in ["isna", "isnull"]:
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects.  Look up the Nimble QueryString object in the documentation.") from e
-            elif name in ["sum", "cumsum", "corr", "nunique"]:
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Check for similar methods available in Nimble.calculate.") from e
-            elif name == "scatter_matrix":
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Try .plotFeatureAgainstFeature()instead.") from e
-            elif name == "dropna":
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Look up how to combine .[points/features].delete with the Nimble.match in the documentation.") from e
-            elif name == "fillna":
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Look up how to use Nimble.fill in the documentation.") from e
-            elif name == "insert":
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Try .[points/features].insert() instead.") from e
-            elif name == "sort_values":
-                raise AttributeError(f"Attribute {name} does not exist for Nimble data objects. Try .[points/features].sort() instead.") from e
-            else:
-                raise AttributeError(f"Invalid attribute: '{name}' is not recognized.") from e
+        # Want to pull msg out from raise, since that line is included
+        # in the traceback and otherwise would clutter the output.
+        base = f"Attribute {name} does not exist for Nimble data objects. "
+        if name == "hist":
+            msg = "Try .plotFeatureDistribution() instead."
+            raise AttributeError(base + msg)
+        elif name == 'describe':
+            msg = "Try .report() instead."
+            raise AttributeError(base + msg)
+        elif name == "columns":
+            msg = "Try .features.getNames() instead."
+            raise AttributeError(base + msg)
+        elif name in ["isna", "isnull"]:
+            msg = "Look up the Nimble QueryString object in the documentation."
+            raise AttributeError(base + msg)
+        elif name in ["sum", "cumsum", "corr", "nunique"]:
+            msg = "Check for similar methods available in Nimble.calculate."
+            raise AttributeError(base + msg)
+        elif name == "scatter_matrix":
+            msg = "Try .plotFeatureAgainstFeature()instead."
+            raise AttributeError(base + msg)
+        elif name == "dropna":
+            msg = "Look up how to combine .[points/features].delete with the Nimble.match in the documentation."
+            raise AttributeError(base + msg)
+        elif name == "fillna":
+            msg = "Look up how to use Nimble.fill in the documentation."
+            raise AttributeError(base + msg)
+        elif name == "insert":
+            msg = "Try .[points/features].insert() instead."
+            raise AttributeError(base + msg)
+        elif name == "sort_values":
+            msg = "Try .[points/features].sort() instead."
+            raise AttributeError(base + msg)
+        else:
+            # this re-triggers standard handling without any recursion, which
+            # includes proper instantion of the error so that name suggestions
+            # can be displayed.
+            return self.__getattribute__(name)
 
     ############################
     ############################

--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -697,7 +697,8 @@ class HighDimensionModifyingSparseSafe(DataTestObject):
             '__floordiv__', '__rfloordiv__', '__ifloordiv__', '__mod__',
             '__rmod__', '__imod__', '__pow__', '__rpow__', '__ipow__',
             '__str__', '__repr__', '__pos__', '__neg__', '__abs__', '__copy__',
-            '__deepcopy__', 'isApproximatelyEqual', 'trainAndTestSets',
+            '__deepcopy__', '__getattr__', 'isApproximatelyEqual',
+            'trainAndTestSets',
             'report', 'isIdentical', 'getTypeString', 'pointView', 'view',
             'checkInvariants', 'containsZero', 'save', 'toString', 'show',
             'copy', 'flatten', 'unflatten',))

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -332,6 +332,7 @@ for call in classes:
 
 baseDunder_tested = list(map(prefixAdder('Base'),
     ['__abs__', '__add__', '__and__', '__bool__', '__copy__', '__deepcopy__',
+     '__getattr__',
      '__getitem__', '__floordiv__', '__iadd__', '__ifloordiv__', '__imod__',
      '__imatmul__', '__imul__', '__invert__', '__ipow__', '__isub__',
      '__iter__', '__itruediv__', '__len__', '__matmul__', '__mod__', '__mul__',


### PR DESCRIPTION
Corrects two small test failures by adding `"__getattr__"` to the appropriate checking lists for logging (which affirms we have tested this method) and high dimensionality checks (which affirms this method is runnable on multi-dimensional data). 

Other changes came out of viewing the outputs as the user would see them, and trying to trim it down to the important parts.

1) Removed the call to super. Remember that I was originally mistaken about needing this; according to the docs, `__getattr__` is called only after the normal process of discovery for an attribute fails. Including this just added another traceback to the exception output (because the new one was raised within a try except). It was therefore removed so as not to double the length.

2) Pulled the exception message to a different line from where the exception is raised. The `raise` line is included in the traceback, and if it included the entirety of the message then it would essentially be printed twice whenever an exception was raised.

3) Instead of raising our own exception if we have no alternative to suggest, this re-calls `__getattribute__` (which is where the normal discovery process is run). The `AttributeError` is instead raised there, which allows for python 3.10 and above to do the special lexical suggestions when displaying the exception to the user.

For (3) I tried a couple of different things that didn't work. First attempt was to somehow reraise the exception that brought us into `__getattr__`  but it's not in scope, and there's a solid handful of issues of people requesting it in the cpython github. Second attempt was to  instantiate an `AttributeError` with the correct arguments. Since the suggestions are done by the exception printing, that needs to be able to access the name and object. But I couldn't figure out how to bundle that information into the `AttributeError` - passing them in during instantiation or setting them afterwards didn't see to work. So, in the end, the call to `__getattribute__` was used instead.