### PR TITLE
Corrections to the direct call stats methods on pts/fts

### DIFF
--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -1622,7 +1622,8 @@ class Axis(ABC):
 
     def _populationStandardDeviation(self, groupByFeature=None):
         FuncName = 'populationstd'
-        toCall = nimble.calculate.standardDeviation(self._base, False)
+        calcSTD = nimble.calculate.standardDeviation
+        toCall = functools.partial(calcSTD, sample=False)
         result = self._process_statistics(FuncName, toCall, groupByFeature)
         return result
 

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -2663,9 +2663,8 @@ class Features(ABC):
     ################
     # Stats methods #
     ###############
-    
+
     def max(self, groupByFeature=None):
-        
         """
         Returns a nimble object representing the maximum
         value along the features axis.
@@ -2673,10 +2672,10 @@ class Features(ABC):
         Parameters
         ----------
         groupByFeature : identifier, None
-            An optional index or name of the feature that makes 
+            An optional index or name of the feature that makes
             the result grouped by the point values along the chosen
             feature axis.
-                       
+
         See Also
         --------
         minimum
@@ -2685,16 +2684,16 @@ class Features(ABC):
         --------
         >>> lst = [[0, 22, 2], [3, 22, 5]]
         >>> X = nimble.data(lst)
-        >>> X.features.maximum()
+        >>> X.features.max()
         <Matrix 1pt x 3ft
-                  0 1  2
-                ┌───────
-          'max' │ 3 22 5
+                 0 1  2
+               ┌───────
+         'max' │ 3 22 5
+        >
         """
         return self._max(groupByFeature)
-    
+
     def mean(self, groupByFeature=None):
-        
         """
         Returns a nimble object representing the mean
         value along the features axis.
@@ -2719,11 +2718,11 @@ class Features(ABC):
                     0     1      2
                 ┌───────────────────
          'mean' │ 1.500 22.000 3.500
+        >
         """
         return self._mean(groupByFeature)
-    
+
     def median(self, groupByFeature=None):
-        
         """
         Returns a nimble object representing the median
         value along the features axis.
@@ -2748,10 +2747,10 @@ class Features(ABC):
                       0     1      2
                   ┌───────────────────
          'median' │ 1.500 22.000 3.500
+        >
         """
-        
         return self._median(groupByFeature)
-    
+
     def min(self, groupByFeature=None):
         """
         Returns a nimble object representing the minimum
@@ -2772,11 +2771,12 @@ class Features(ABC):
         --------
         >>> lst = [[0, 22, 2], [3, 22, 5]]
         >>> X = nimble.data(lst)
-        >>> X.features.minimum()
+        >>> X.features.min()
         <Matrix 1pt x 3ft
-                  0 1  2
-                ┌───────
-          'min' │ 0 22 2
+                 0 1  2
+               ┌───────
+         'min' │ 0 22 2
+        >
         """
         return self._min(groupByFeature)
     
@@ -2801,6 +2801,7 @@ class Features(ABC):
                          0 1 2
                        ┌──────
          'uniquecount' │ 2 1 2
+        >
         """
         
         return self._uniqueCount(groupByFeature)
@@ -2826,7 +2827,7 @@ class Features(ABC):
                                  0     1     2
                              ┌──────────────────
          'proportionmissing' │ 0.500 0.000 0.500
-        
+        >
         """
         return self._proportionMissing(groupByFeature)
 
@@ -2848,10 +2849,10 @@ class Features(ABC):
         >>> X = nimble.data(lst)
         >>> X.features.proportionZero()
         <Matrix 1pt x 3ft
-                             0     1     2
-                         ┌──────────────────
-        'proportionzero' │ 0.500 0.500 0.500
-        
+                              0     1     2
+                          ┌──────────────────
+         'proportionzero' │ 0.500 0.500 0.500
+        >
         """
         return self._proportionZero(groupByFeature)
 
@@ -2873,9 +2874,10 @@ class Features(ABC):
         >>> X = nimble.data(lst)
         >>> X.features.standardDeviation()
         <Matrix 1pt x 3ft
-                  0     1     2
-              ┌──────────────────
-        'std' │ 2.121 0.000 2.121   
+                   0     1     2
+               ┌──────────────────
+         'std' │ 2.121 0.000 2.121
+        >
         """
         return self._standardDeviation(groupByFeature)
 
@@ -2901,6 +2903,7 @@ class Features(ABC):
                              0     1     2
                          ┌──────────────────
          'populationstd' │ 1.500 0.000 1.500
+        >
         """
         return self._populationStandardDeviation(groupByFeature)
     

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -2570,12 +2570,13 @@ class Points(ABC):
         --------
         >>> lst = [[0, 22, 2], [3, 22, 5]]
         >>> X = nimble.data(lst)
-        >>> X.points.maximum()
+        >>> X.points.max()
         <Matrix 2pt x 1ft
              'max'
            ┌──────
          0 │   22
          1 │   22
+        >
         """
         return self._max()
 
@@ -2598,6 +2599,7 @@ class Points(ABC):
            ┌───────
          0 │ 8.000
          1 │ 10.000
+        >
         """
         return self._mean()
     
@@ -2620,8 +2622,7 @@ class Points(ABC):
            ┌─────────
          0 │  2.000
          1 │  5.000
-
-
+        >
         """
         return self._median()
     
@@ -2638,12 +2639,13 @@ class Points(ABC):
         --------
         >>> lst = [[0, 22, 2], [3, 22, 5]]
         >>> X = nimble.data(lst)
-        >>> X.points.minimum(vector)
+        >>> X.points.min()
         <Matrix 2pt x 1ft
              'min'
            ┌──────
          0 │   0
          1 │   3
+        >
         """
         return self._min()
     
@@ -2662,7 +2664,7 @@ class Points(ABC):
            ┌──────────────
          0 │       3
          1 │       3
-
+        >
         """
         return self._uniqueCount()
 
@@ -2681,7 +2683,7 @@ class Points(ABC):
            ┌────────────────────
          0 │        0.333
          1 │        0.333
-
+        >
         """
         return self._proportionMissing()
 
@@ -2700,7 +2702,7 @@ class Points(ABC):
            ┌─────────────────
          0 │      0.333
          1 │      0.667
-        
+        >
         """
         return self._proportionZero()
 
@@ -2719,6 +2721,7 @@ class Points(ABC):
            ┌───────
          0 │ 12.166
          1 │ 10.440
+        >
         '''
         return self._standardDeviation()
 
@@ -2737,6 +2740,7 @@ class Points(ABC):
            ┌────────────────
          0 │      9.933
          1 │      8.524
+        >
         """ 
         return self._populationStandardDeviation()
     


### PR DESCRIPTION
* Most were missing the closing greater than to end the printed repr. See https://docs.python.org/3/reference/datamodel.html#object.__repr__
* some whitespace removal or addition; sometimes required for passing, sometimes just for aesthetics.
* There was an error when calculating populate std where the function that was meant to be called later was accidentally evaluated before then. This was corrected with the usage of a partial function https://docs.python.org/3/library/functools.html#functools.partial
* min/max methods were called using their defined names. We will discuss later whether we like the abbreviations, but for now those docstrings will pass.

I'll be looking at the test failures next.