### PR TITLE
Adjust direct stats method tests to use the correct constructor

### DIFF
--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -4247,77 +4247,66 @@ class HighLevelModifyingSparseSafe(DataTestObject):
     
     def test_points_max(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = nimble.data([[22],[22]], 
-                            featureNames=['max'], returnType=constructor.keywords['returnType'])
-            exp = toTest.points.statistics('max')
-            res = toTest.points.max()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('max')
+        res = toTest.points.max()
+        assert exp == res
     
     def test_points_min(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('min')
-            res = toTest.points.min()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('min')
+        res = toTest.points.min()
+        assert exp == res
     
     def test_points_mean(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('mean')
-            res = toTest.points.mean()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('mean')
+        res = toTest.points.mean()
+        assert exp == res
     
     def test_points_median(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('median')
-            res = toTest.points.median()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('median')
+        res = toTest.points.median()
+        assert exp == res
     
     def test_points_unique_count(self):
         raw =  [[1, 2, 0], [0,0,5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('unique count')
-            res = toTest.points.uniqueCount()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('unique count')
+        res = toTest.points.uniqueCount()
+        assert exp == res
     
     def test_points_proportion_missing(self):
         raw = [[1, 2, 0], [0, float('nan'),5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('proportion missing')
-            res = toTest.points.proportionMissing()
-            assert exp == res 
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('proportion missing')
+        res = toTest.points.proportionMissing()
+        assert exp == res
     
     def test_points_proportion_zero(self):
         raw = [[1, 2, 0], [0,0,5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('proportion zero')
-            res = toTest.points.proportionZero()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('proportion zero')
+        res = toTest.points.proportionZero()
+        assert exp == res
     
     def test_points_standard_deviation(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('std')
-            res = toTest.points.standardDeviation()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('std')
+        res = toTest.points.standardDeviation()
+        assert exp == res
             
     def test_points_population_standard_deviation(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.points.statistics('populationstd')
-            res = toTest.points.populationStandardDeviation()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.points.statistics('populationstd')
+        res = toTest.points.populationStandardDeviation()
+        assert exp == res
             
         
         
@@ -4327,74 +4316,63 @@ class HighLevelModifyingSparseSafe(DataTestObject):
     
     def test_features_max(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('max')
-            res = toTest.features.max()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('max')
+        res = toTest.features.max()
+        assert exp == res
     
     def test_features_min(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('min')
-            res = toTest.features.min()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('min')
+        res = toTest.features.min()
+        assert exp == res
     
     def test_features_mean(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('mean')
-            res = toTest.features.mean()
-            assert exp == res
-    
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('mean')
+        res = toTest.features.mean()
+        assert exp == res
+
     def test_features_median(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('median')
-            res = toTest.features.median()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('median')
+        res = toTest.features.median()
+        assert exp == res
     
     def test_features_unique_count(self):
         raw = [[1, 0, 0], [0,0,5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('unique count')
-            res = toTest.features.uniqueCount()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('unique count')
+        res = toTest.features.uniqueCount()
+        assert exp == res
     
     def test_features_proportion_missing(self):
         raw = [[1, 2, 0], [0, float('nan'),5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp =   toTest.features.statistics('proportion missing')
-            res = toTest.features.proportionMissing()
-            assert exp == res 
+        toTest = self.constructor(raw)
+        exp =   toTest.features.statistics('proportion missing')
+        res = toTest.features.proportionMissing()
+        assert exp == res
     
     def test_features_proportion_zero(self):
         raw = [[1, 2, 0], [0,0,5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('proportion zero')
-            res = toTest.features.proportionZero()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('proportion zero')
+        res = toTest.features.proportionZero()
+        assert exp == res
     
     def test_features_standard_deviation(self):
         raw = [[1, 2, 0], [0,0,5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('std')
-            res = toTest.features.standardDeviation()
-            assert exp == res
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('std')
+        res = toTest.features.standardDeviation()
+        assert exp == res
     
     def test_features_population_standard_deviation(self):
         raw = [[0, 22, 2], [3, 22, 5]]
-        for constructor in getDataConstructors():
-            toTest = constructor(raw)
-            exp = toTest.features.statistics('populationstd')
-            res = toTest.features.populationStandardDeviation()
-            assert exp == res    
-        
-
+        toTest = self.constructor(raw)
+        exp = toTest.features.statistics('populationstd')
+        res = toTest.features.populationStandardDeviation()
+        assert exp == res


### PR DESCRIPTION
Since these tests are within test objects, we need to refer to the object's constructor. By iterating through a generated list, each test object was running the test for each kind of data object, resulting in a multiplicative level of redundant execution.