### PR TITLE
Explanation extensions

### DIFF
--- a/documentation/source/examples/exploring_data.py
+++ b/documentation/source/examples/exploring_data.py
@@ -22,7 +22,6 @@ In this example we will learn about:
 [files]: files.rst#exploring-data
 [datasets]: ../datasets.rst#exploring-data
 """
-
 ## Getting Started ##
 
 import nimble
@@ -102,7 +101,7 @@ correlations[:, 'Purchase'].show('Feature correlations with Purchase')
 ## including a 'query'. In Nimble, a query is a string expression that returns
 ## a boolean value after the expression is evaluated, in this case for each
 ## point in the data. The boolean results will determine if a point should be 
-## copied or not. See Nimble's QueryString documentation for more details.
+## copied or not. See Nimble's `QueryString` documentation for more details.
 special = visits.points.copy('SpecialDay > 0')
 visitPercent = len(special.points) / len(visits.points) * 100
 print(f'{visitPercent:.2f}% of all visits were near a special day')

--- a/documentation/source/examples/unsupervised_learning.py
+++ b/documentation/source/examples/unsupervised_learning.py
@@ -37,10 +37,11 @@ visits = nimble.data(bucket + 'online_shoppers_intention_clean.csv',
 
 ## We are going to focus on categorizing our visitors that made a purchase.
 ## First, we will copy any data points for visits that resulted in a purchase
-## into a new object. The 'copy' method accepts a variety of arguments including
-## functions. In this case of 'points.copy', the function must accept each
-## element of the points axis and return a boolean value, this will determine if
-## the point should be copied or not.
+## into a new object. The `points.copy` method accepts a variety of arguments
+## including user defined functions. In that case, the function must accept
+## an object that represents a single point (as if grabbing a single slice
+## out of the points axis) and return a boolean indicating if
+## that point should be copied or not.
 purchaseOnly = visits.points.copy(lambda pt: pt['Purchase'])
 
 ## The Purchase feature in `purchaseOnly` now only contains the value `True`.


### PR DESCRIPTION
Proposed further explanation changes. First is to link to the querystring docs, and second to modify the wording when describing the api for functions passed to copy.