### PR TITLE
Adjust line break issue in exploring data's expected output.

### DIFF
--- a/tests/landingPage/exploring_data_output.txt
+++ b/tests/landingPage/exploring_data_output.txt
@@ -1,7 +1,5 @@
 Features in dataset:
-['Administrative', 'Admin_Duration', 'Informational', 'Info_Duration', 'ProductRelated', 'Product_Duration', 'BounceR
-ates', 'ExitRates', 'PageValues', 'SpecialDay', 'Month', 'OperatingSystems', 'Browser', 'Region', 'TrafficType', 'New
-Visitor', 'Weekend', 'Purchase']
+['Administrative', 'Admin_Duration', 'Informational', 'Info_Duration', 'ProductRelated', 'Product_Duration', 'BounceRates', 'ExitRates', 'PageValues', 'SpecialDay', 'Month', 'OperatingSystems', 'Browser', 'Region', 'TrafficType', 'NewVisitor', 'Weekend', 'Purchase']
 Page activity features
 12212pt x 6ft
         'Administrative' 'Admin_Duration' 'Informational' 'Info_Duration' 'ProductRelated' 'Product_Duration'


### PR DESCRIPTION
Since we are printing a list, not a nimble object, the list output will not include any line breaks, even if it visually spans multiple lines