### PR TITLE
Sparse setitem corrections + test

### DIFF
--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -373,34 +373,6 @@ class Axis(ABC):
             return self._base.pointView(key[0]).copy()
         return self._structuralBackend_implementation('copy', key)
     
-    def _setitem(self, key, value):
-      # Determine if the key is a single key based on its type
-        singleKey = isinstance(key, (int, float, str, np.integer))
-
-        # Convert the key into appropriate indices
-        if singleKey:
-            key = [self._getIndex(key, allowFloats=True)]
-        else:
-            key = self._processMultiple(key)
-
-        # If key resolution returns None, assume an attempt to set the whole base
-        if key is None:
-            if isinstance(value, type(self._base)):
-                self._base = value.copy()
-            else:
-                raise ValueError("Incompatible value type for full assignment")
-            return
-
-        # Handling the setting operation
-        if singleKey and len(self._base._dims) > 2:
-            # If the structure has more than two dimensions and a single key is provided
-            self._base.pointView(key[0]).update(value)
-        else:
-            # General case for setting multiple indices
-            self._structuralBackend_implementation('set', key, value)
-
-
-
     def _anyDefaultNames(self):
         return self.names is None or len(self.names) < len(self)
 

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -852,7 +852,8 @@ class Sparse(Base):
                     self._data.data = np.delete(self._data.data, k)
                     self._data.row = np.delete(self._data.row, k)
                     self._data.col = np.delete(self._data.col, k)
-                    self._sortInternal(self._sorted['axis'], setIndices=True)  # Re-sort and re-index
+                    # Re-sort and re-index
+                    self._sortInternal(self._sorted['axis'], setIndices=True, forceSort=True)
                 return
         if value != 0:
             numPts = len(list(self.points))
@@ -865,8 +866,8 @@ class Sparse(Base):
                 (self._data.data, (self._data.row, self._data.col)),
                  shape=(numPts,numFts)
             )
-            self._sortInternal(self._sorted['axis'], setIndices=True)  # Re-sort and re-index
-            self._sorted['axis'] = None
+            # Re-sort and re-index
+            self._sortInternal(self._sorted['axis'], setIndices=True, forceSort=True)
             
     def _view_implementation(self, pointStart, pointEnd, featureStart,
                              featureEnd, dropDimension):
@@ -1225,8 +1226,8 @@ class Sparse(Base):
     # Helpers #
     ###########
 
-    def _sortInternal(self, axis, setIndices=False):
-        if self._sorted['axis'] == axis:
+    def _sortInternal(self, axis, setIndices=False, forceSort=False):
+        if self._sorted['axis'] == axis and not forceSort:
             # axis sorted; can return now if do not need to set indices
             if not setIndices or self._sorted['indices'] is not None:
                 return

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -3139,6 +3139,15 @@ class HighLevelModifyingSparseSafe(DataTestObject):
         assert toTest[2,2] == exp3
         assert toTest[1,4] == exp4
 
+        # Zero entry manipulation checks that may be relevant for sparse
+        toTest[0,3] = -10
+        toTest[1,0] = 0
+        toTest[2,1] = 0
+
+        assert toTest[0,3] == -10
+        assert toTest[1,0] == 0
+        assert toTest[2,1] == 0
+
     ####################################
     # replaceFeatureWithBinaryFeatures #
     ####################################

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -362,7 +362,8 @@ baseDunder_tested = list(map(prefixAdder('Base'),
      '__iter__', '__itruediv__', '__len__', '__matmul__', '__mod__', '__mul__',
      '__neg__', '__or__', '__pos__', '__pow__', '__radd__', '__rfloordiv__',
      '__rmatmul__', '__rmod__', '__rmul__', '__rpow__', '__rsub__',
-     '__rtruediv__', '__sub__', '__truediv__', '__xor__',
+     '__rtruediv__', '__sub__', '__setitem__',
+     '__truediv__', '__xor__',
     ]))
 axisDunder_tested = ['Axis.__bool__', 'Axis.__len__']
 pointsDunder_tested = ['Points.__iter__', 'Points.__getitem__']


### PR DESCRIPTION
Fixes sort handling in the Sparse setitem implementation. Previously, the sort was not being triggered because it was already marked as being sorted. Instead of manually setting _sorted to None, the sort method has been modified with a parameter that will force sorting when desired.

The setitem unit test was extended to include some zero manipulations that would check the various cases for Sparse.

The unused axis based setitem partial implementation has been removed.

EDITED TO ADD: correction to the logging tests so setitem is marked as being tested with no log entries